### PR TITLE
change shortcut command from meteor_reload to meteor_reval

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,5 @@
 [
     {
-        "keys": ["ctrl+alt+s"], "command": "meteor_reload"
+        "keys": ["ctrl+alt+s"], "command": "meteor_reval"
     }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,5 @@
 [
     {
-        "keys": ["ctrl+alt+s"], "command": "meteor_reload"
+        "keys": ["ctrl+alt+s"], "command": "meteor_reval"
     }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,5 @@
 [
     {
-        "keys": ["ctrl+alt+s"], "command": "meteor_reload"
+        "keys": ["ctrl+alt+s"], "command": "meteor_reval"
     }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,6 @@
 [
     {
-        "caption": "Meteor Reload",
-        "command": "meteor_reload"
+        "caption": "Meteor Reval",
+        "command": "meteor_reval"
     }
 ]


### PR DESCRIPTION
Following http://docs.sublimetext.info/en/latest/extensibility/plugins.html "Conventions for Command names", an outdated command name was being called for keyboard shortcuts, causing keyboard shortcuts not to work for the reval plugin.