### PR TITLE
defer load_settings until sublime api available

### DIFF
--- a/MeteorReval.py
+++ b/MeteorReval.py
@@ -4,8 +4,11 @@ import sublime_plugin
 import urllib.request
 import re
 
+settings = None
 
-settings = sublime.load_settings("MeteorReval.sublime-settings")
+def plugin_loaded():
+    global settings
+    settings = sublime.load_settings("MeteorReval.sublime-settings")
 
 class meteorReval(sublime_plugin.EventListener):
     pending = 0


### PR DESCRIPTION
The Sublime API was not available when `sublime.load_settings` was called, causing the plugin to occasionally not work until reload. We now defer `load_settings` until the Sublime API is ready.